### PR TITLE
Fixes inclusion of Eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,8 @@ if(DEFINED EXTRA_LIBRARY_PATH)
 endif()
 
 find_package(Eigen3 REQUIRED)
-include_directories(${EIGEN3_INCLUDE_DIRS})
+get_filename_component(PARENT_DIR ${EIGEN3_INCLUDE_DIR} DIRECTORY)
+include_directories(${PARENT_DIR})
 
 find_package(Yeppp)
 if(YEPPP_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(DEFINED EXTRA_LIBRARY_PATH)
 endif()
 
 find_package(Eigen3 REQUIRED)
-get_filename_component(PARENT_DIR ${EIGEN3_INCLUDE_DIR} DIRECTORY)
+get_filename_component(PARENT_DIR ${EIGEN3_INCLUDE_DIR} PATH)
 include_directories(${PARENT_DIR})
 
 find_package(Yeppp)

--- a/Makefile
+++ b/Makefile
@@ -16,21 +16,18 @@ endif
 cmake_args=
 nose_env:=NOSE_PROCESSES=$(cpu_count) NOSE_PROCESS_TIMEOUT=240
 ifdef VIRTUAL_ENV
-	cmake_args=-DCMAKE_INSTALL_PREFIX=$(VIRTUAL_ENV)
-	library_path=$(LIBRARY_PATH):$(VIRTUAL_ENV)/lib/
-	nose_env+=$(ld_library_path)=$($(ld_library_path)):$(VIRTUAL_ENV)/lib/
+	root_path=$(VIRTUAL_ENV)
 else
 	ifdef CONDA_ROOT
-		cmake_args=-DCMAKE_INSTALL_PREFIX=$(CONDA_ROOT)
-		library_path=$(LIBRARY_PATH):$(CONDA_ROOT)/lib/
-		nose_env+=$(ld_library_path)=$($(ld_library_path)):$(CONDA_ROOT)/lib/
+		root_path=$(CONDA_ROOT)
 	else
-		cmake_args=-DCMAKE_INSTALL_PREFIX=../..
-		library_path=$(LIBRARY_PATH):`pwd`/lib/
-		nose_env+=$(ld_library_path)=$($(ld_library_path)):`pwd`/lib/
-
+		root_path='../..'
 	endif
 endif
+cmake_args=-DCMAKE_INSTALL_PREFIX=$(root_path)
+library_path=$(LIBRARY_PATH):$(root_path)/lib/
+nose_env+=$(ld_library_path)=$($(ld_library_path)):$(root_path)/lib/
+
 ifdef CMAKE_INSTALL_PREFIX
 	cmake_args=-DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)
 endif

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,16 @@ ifdef VIRTUAL_ENV
 	library_path=$(LIBRARY_PATH):$(VIRTUAL_ENV)/lib/
 	nose_env+=$(ld_library_path)=$($(ld_library_path)):$(VIRTUAL_ENV)/lib/
 else
-	cmake_args=-DCMAKE_INSTALL_PREFIX=../..
-	library_path=$(LIBRARY_PATH):`pwd`/lib/
-	nose_env+=$(ld_library_path)=$($(ld_library_path)):`pwd`/lib/
+	ifdef CONDA_ROOT
+		cmake_args=-DCMAKE_INSTALL_PREFIX=$(CONDA_ROOT)
+		library_path=$(LIBRARY_PATH):$(CONDA_ROOT)/lib/
+		nose_env+=$(ld_library_path)=$($(ld_library_path)):$(CONDA_ROOT)/lib/
+	else
+		cmake_args=-DCMAKE_INSTALL_PREFIX=../..
+		library_path=$(LIBRARY_PATH):`pwd`/lib/
+		nose_env+=$(ld_library_path)=$($(ld_library_path)):`pwd`/lib/
+
+	endif
 endif
 ifdef CMAKE_INSTALL_PREFIX
 	cmake_args=-DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ if os.environ.get('CXX', '').startswith('g++'):
 include_dirs = ['include', 'distributions']
 include_dirs.append(numpy.get_include())
 
+conda_include = os.path.join(os.path.dirname(sys.executable), "../include")
+include_dirs.append(conda_include)
 if 'EXTRA_INCLUDE_PATH' in os.environ:
     include_dirs.append(os.environ['EXTRA_INCLUDE_PATH'])
 

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,6 @@ if os.environ.get('CXX', '').startswith('g++'):
 include_dirs = ['include', 'distributions']
 include_dirs.append(numpy.get_include())
 
-conda_include = os.path.join(os.path.dirname(sys.executable), "../include")
-include_dirs.append(conda_include)
 if 'EXTRA_INCLUDE_PATH' in os.environ:
     include_dirs.append(os.environ['EXTRA_INCLUDE_PATH'])
 


### PR DESCRIPTION
Fixes inclusion of Eigen3.

FindEigen3.cmake sets `EIGEN3_INCLUDE_DIR` not `EIGEN3_INCLUDE_DIRS`. This make CMakeLists.txt reference the correct variable. Also include the parent path `/eigen3/...` instead of the path
found by FindEigen3.cmake so the `#include <eigen3/Eigen/*>` statements work.

Also modifies makefile to allow user to set `CONDA_ROOT` environmental variable (to root directory of a conda environment) which will then be used as the `CMAKE_INSTALL_PREFIX`. Among other things, this allows the user to use `conda install eign3` for installation of Eigen3. 

`CONDA_ROOT` can typically be set with `export CONDA_ROOT=$(conda info | grep "default environment" | cut -d ":" -f2)`. 

There's an [open ticket](https://github.com/conda/conda-env/issues/63) about adding the conda env root as an environmental variable when you source it.
