### PR TITLE
Fixes for Ubuntu 1604

### DIFF
--- a/include/distributions/timers.hpp
+++ b/include/distributions/timers.hpp
@@ -25,7 +25,7 @@
 // TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# pragma once
+#pragma once
 
 #include <distributions/common.hpp>
 #include <sys/time.h>

--- a/include/distributions/vector.hpp
+++ b/include/distributions/vector.hpp
@@ -46,7 +46,9 @@ struct Packed_ : std::vector<Value, Alloc> {
 
     void packed_remove(size_t pos) {
         DIST_ASSERT1(pos < Base::size(), "bad pos: " << pos);
-        Base::operator[](pos) = std::move(Base::back());
+        if (pos != Base::size() - 1) {
+            Base::operator[](pos) = std::move(Base::back());
+        }
         Base::pop_back();
     }
 


### PR DESCRIPTION
Fixes https://github.com/posterior/loom/issues/6

- Avoid `std::move()` to self due to stricter requirements of `std::move()`
- Replace `# pragma once` with `#pragma once` due to stricter `cpplint`