### PR TITLE
Fix numpy strict conversion error, (related to issue #15).

### DIFF
--- a/distributions/util.py
+++ b/distributions/util.py
@@ -29,7 +29,7 @@ import numpy
 
 
 def scores_to_probs(scores):
-    scores = numpy.array(scores)
+    scores = numpy.array(scores, dtype='d')
     scores -= scores.max()
     probs = numpy.exp(scores, out=scores)
     probs /= probs.sum()


### PR DESCRIPTION
Partially addresses https://github.com/posterior/distributions/issues/15 by fixing depracated use of numpy.

I'm not sure of the best solution to address `FAIL: distributions.tests.test_models.test_add_remove('lp.models.niw',)` in #15, so I will leave that as a separate pull request.